### PR TITLE
Denoiser Fixes: Use build in materials for color conversion, fix denoiser blocking fade animation

### DIFF
--- a/src/core/OIDNDenoiser.js
+++ b/src/core/OIDNDenoiser.js
@@ -206,15 +206,11 @@ export class OIDNDenoiser {
 
 		}
 
-<<<<<<< HEAD
 		// should we force to canvas or allow the user to set to their own target?
 		const currentAutoClear = this.renderer.autoClear;
 		this.renderer.autoClear = false;
 		this.quad.render( this.renderer );
 		this.renderer.autoClear = currentAutoClear;
-=======
-		this.quad.render( this.renderer );
->>>>>>> 9e43cd4f85e17edec505ad522c1588cf6f59851f
 
 	}
 

--- a/src/core/OIDNDenoiser.js
+++ b/src/core/OIDNDenoiser.js
@@ -108,21 +108,20 @@ export class OIDNDenoiser {
 		this.t2conversion = false;
 
 		// Same as pathtracer so tonemapping is the same
-		this.ptMaterial = new MeshBasicMaterial( {
+		this.linearToSRGBMaterial = new MeshBasicMaterial( {
 			map: null,
 			transparent: true,
 			blending: NoBlending,
-			premultipliedAlpha: renderer.getContextAttributes().premultipliedAlpha,
 		} );
 
 		// Material to blend between pathtracer and denoiser
-		this.blendMaterial = new ClampedInterpolationMaterial( {
+		this.blendToCanvasMaterial = new ClampedInterpolationMaterial( {
 			map: null,
 			transparent: true,
 			premultipliedAlpha: renderer.getContextAttributes().premultipliedAlpha,
 		} );
 
-		this.quad = new FullScreenQuad( this.ptMaterial );
+		this.quad = new FullScreenQuad( this.linearToSRGBMaterial );
 		this.createConversionRenderTarget( renderer.domElement.width, renderer.domElement.height );
 
 	}
@@ -191,15 +190,15 @@ export class OIDNDenoiser {
 		if ( ! this.denoisedTexture ) return;
 
 		//const currentTarget = this.renderer.getRenderTarget();
-		this.quad.material = this.blendMaterial;
-		this.blendMaterial.map = this.denoisedTexture;
-		this.blendMaterial.opacity = Math.min( ( performance.now() - this.denoiserFinished ) / this.fadeTime, 1 );
+		this.quad.material = this.blendToCanvasMaterial;
+		this.blendToCanvasMaterial.map = this.denoisedTexture;
+		this.blendToCanvasMaterial.opacity = Math.min( ( performance.now() - this.denoiserFinished ) / this.fadeTime, 1 );
 
 		// Lets us see the aux textures
 		if ( bypassTexture ) {
 
-			this.blendMaterial.map = bypassTexture;
-			this.blendMaterial.opacity = 1;
+			this.blendToCanvasMaterial.map = bypassTexture;
+			this.blendToCanvasMaterial.opacity = 1;
 
 		}
 
@@ -228,8 +227,8 @@ export class OIDNDenoiser {
 	getLinearToSRGBTexture( pathtracedTexture, target ) {
 
 		const oldRenderTarget = this.renderer.getRenderTarget();
-		this.quad.material = this.ptMaterial;
-		this.ptMaterial.map = pathtracedTexture;
+		this.quad.material = this.linearToSRGBMaterial;
+		this.linearToSRGBMaterial.map = pathtracedTexture;
 		this.renderer.setRenderTarget( target );
 		this.quad.render( this.renderer );
 		this.renderer.setRenderTarget( oldRenderTarget );

--- a/src/core/utils/AlbedoNormalPass.js
+++ b/src/core/utils/AlbedoNormalPass.js
@@ -1,6 +1,4 @@
 import { WebGLRenderTarget, SRGBColorSpace, Mesh, MeshNormalMaterial, MeshBasicMaterial, NoBlending } from 'three';
-import { FullScreenQuad } from 'three/examples/jsm/Addons.js';
-import { ClampedInterpolationMaterial } from '../../materials/fullscreen/ClampedInterpolationMaterial.js';
 
 // Material pool
 class MaterialPool {
@@ -110,8 +108,6 @@ export class AlbedoNormalPass {
 		this.albedoRenderTarget.setSize( width, height );
 		this.normalRenderTarget.setSize( width, height );
 
-		if ( ! this.quad ) this.setupQuad( renderer );
-
 		const oldRenderTarget = renderer.getRenderTarget();
 
 		// Normal pass
@@ -133,24 +129,6 @@ export class AlbedoNormalPass {
 
 		// return the two textures
 		return { albedo: this.albedoRenderTarget.texture, normal: this.normalRenderTarget.texture };
-
-	}
-
-	setupQuad( renderer ) {
-
-		// for converting to srgb
-		// Same as pathtracer so tonemapping is the same
-		this.ptMaterial = new ClampedInterpolationMaterial( {
-			map: null,
-			transparent: true,
-			blending: NoBlending,
-
-			premultipliedAlpha: renderer.getContextAttributes().premultipliedAlpha,
-		} );
-		this.ptMaterial.opacity = 1;
-		// get the pathtracer to output in SRGB
-		this.ptMaterial.uniforms.convertToSRGB.value = true;
-		this.quad = new FullScreenQuad( this.ptMaterial );
 
 	}
 

--- a/src/materials/fullscreen/ClampedInterpolationMaterial.js
+++ b/src/materials/fullscreen/ClampedInterpolationMaterial.js
@@ -40,7 +40,6 @@ export class ClampedInterpolationMaterial extends ShaderMaterial {
 
 				map: { value: null },
 				opacity: { value: 1 },
-				convertToSRGB: { value: false }
 
 			},
 
@@ -115,7 +114,6 @@ export class ClampedInterpolationMaterial extends ShaderMaterial {
 
 					vec4 finalColor = mix( p1, p2, alpha.y );
 					finalColor.a *= opacity;
-					if ( convertToSRGB ) finalColor = LinearToSRGB( finalColor );
 					gl_FragColor = finalColor;
 
 					#include <premultiplied_alpha_fragment>


### PR DESCRIPTION
- Removes some unnecessary material changes and uses three.js built-in materials to perform srgb conversion to simplify things.
- Fix the partially-faded-in path traced view caused by the denoiser blocking the fade animation from completing.
- Fix the "pop" in when transitioning to the denoised view by waiting for the fade animation to finish