### PR TITLE
Improved normals albedo pass for Denoiser

### DIFF
--- a/src/core/utils/AlbedoNormalPass.js
+++ b/src/core/utils/AlbedoNormalPass.js
@@ -95,12 +95,12 @@ class MaterialPool {
 		const material = this._getNextMaterial( type );
 
 		material.map = originalMaterial.map;
-		material.color = originalMaterial.color;
 		material.opacity = originalMaterial.opacity;
 		material.transparent = originalMaterial.transparent;
 		material.depthWrite = originalMaterial.depthWrite;
 		material.alphaTest = originalMaterial.alphaTest;
 		material.alphaMap = originalMaterial.alphaMap;
+		if ( material.color ) material.color.copy( originalMaterial.color );
 		if ( type === 'normal' ) material.normalMap = originalMaterial.normalMap;
 		else material.normalMap = null;
 
@@ -137,9 +137,10 @@ class MaterialPool {
 		if ( mesh.material.map ) mesh.material.map = null;
 		if ( mesh.material.alphaMap ) mesh.material.alphaMap = null;
 		if ( mesh.material.normalMap ) mesh.material.normalMap = null;
-		if ( mesh.material.color ) mesh.material.color = 0xffffff;
+
 		// restore the original material
 		mesh.material = this.originalMaterials.get( mesh );
+
 		// remove our reference to the original material
 		this.originalMaterials.delete( mesh );
 

--- a/src/core/utils/AlbedoNormalPass.js
+++ b/src/core/utils/AlbedoNormalPass.js
@@ -1,11 +1,81 @@
-import { WebGLRenderTarget, SRGBColorSpace, Mesh, MeshNormalMaterial, MeshBasicMaterial, NoBlending } from 'three';
+import { WebGLRenderTarget, SRGBColorSpace, Mesh, MeshNormalMaterial, MeshBasicMaterial, Color, } from 'three';
+
+const _blackColor = /* @__PURE__ */ new Color( 0, 0, 0 );
+
+// A normal material that supports texture partial transparency
+class AlphaMapNormalMaterial extends MeshNormalMaterial {
+
+	get map() {
+
+		return this._uniforms.map.value;
+
+	}
+
+	set map( v ) {
+
+		this._uniforms.map.value = v;
+
+	}
+
+	get alphaMap() {
+
+		return this._uniforms.alphaMap.value;
+
+	}
+
+	set alphaMap( v ) {
+
+		this._uniforms.alphaMap.value = v;
+
+	}
+
+	constructor( ...args ) {
+
+		super( ...args );
+		this._uniforms = {
+			map: { value: null },
+			alphaMap: { value: null },
+		};
+
+	}
+
+	onBeforeCompile( shader ) {
+
+		shader.uniforms = {
+			...shader.uniforms,
+			...this._uniforms,
+		};
+
+		shader.fragmentShader = shader.fragmentShader
+			.replace( /#include <uv_pars_fragment>/, /* glsl */`
+
+				#include <uv_pars_fragment>
+				#include <map_pars_fragment>
+				#include <alphamap_pars_fragment>
+				#include <alphatest_pars_fragment>
+
+			` )
+			.replace( /#include <clipping_planes_fragment>/, /* glsl */`
+
+				#include <map_fragment>
+				#include <color_fragment>
+				#include <alphamap_fragment>
+				#include <alphatest_fragment>
+
+				#include <clipping_planes_fragment>
+
+			` );
+
+	}
+
+}
 
 // Material pool
 class MaterialPool {
 
 	constructor() {
 
-		this.normalMaterial = new MeshNormalMaterial();
+		this.normalMaterial = new AlphaMapNormalMaterial();
 		this.albedoMaterial = new MeshBasicMaterial();
 		this.originalMaterials = new Map();
 
@@ -26,7 +96,15 @@ class MaterialPool {
 
 		material.map = originalMaterial.map;
 		material.color = originalMaterial.color;
+		material.opacity = originalMaterial.opacity;
+		material.transparent = originalMaterial.transparent;
+		material.depthWrite = originalMaterial.depthWrite;
+		material.alphaTest = originalMaterial.alphaTest;
+		material.alphaMap = originalMaterial.alphaMap;
 		if ( type === 'normal' ) material.normalMap = originalMaterial.normalMap;
+		else material.normalMap = null;
+
+		material.needsUpdate = true;
 
 		return material;
 
@@ -57,6 +135,7 @@ class MaterialPool {
 
 		// reset the state of the applied material
 		if ( mesh.material.map ) mesh.material.map = null;
+		if ( mesh.material.alphaMap ) mesh.material.alphaMap = null;
 		if ( mesh.material.normalMap ) mesh.material.normalMap = null;
 		if ( mesh.material.color ) mesh.material.color = 0xffffff;
 		// restore the original material
@@ -111,9 +190,14 @@ export class AlbedoNormalPass {
 		const oldRenderTarget = renderer.getRenderTarget();
 
 		// Normal pass
+		const prevBackground = scene.background;
+		scene.background = _blackColor;
+
 		this.swapMaterials( scene, 'normal' );
 		renderer.setRenderTarget( this.normalRenderTarget );
 		renderer.render( scene, camera );
+
+		scene.background = prevBackground;
 
 		// Albedo pass
 		this.swapMaterials( scene, 'albedo' );
@@ -134,14 +218,16 @@ export class AlbedoNormalPass {
 
 	swapMaterials( object, swapTo = '' ) {
 
-		if ( object instanceof Mesh && object.material ) {
+		object.traverse( child => {
 
-			if ( swapTo ) object.material = this.materialPool.getMaterial( object, swapTo );
-			else this.materialPool.restoreOriginal( object );
+			if ( child instanceof Mesh && child.material ) {
 
-		}
+				if ( swapTo ) child.material = this.materialPool.getMaterial( child, swapTo );
+				else this.materialPool.restoreOriginal( child );
 
-		object.children.forEach( child => this.swapMaterials( child, swapTo ) );
+			}
+
+		} );
 
 	}
 


### PR DESCRIPTION
Depends on #1 

Updates the AlbedoNormalPass to more correctly handle partial transparency and backgrounds.

| before | after |
|---|---|
| ![image](https://github.com/user-attachments/assets/a9157fd1-d3e7-48fc-970a-7f41e05e8509) | ![image](https://github.com/user-attachments/assets/9deb1d92-9bd5-41de-a13a-c60776cdc627) |
| ![image](https://github.com/user-attachments/assets/ea4ce496-8ca3-4268-855c-93d7f707a7c6) | ![image](https://github.com/user-attachments/assets/847c8c37-1a56-4278-8492-d60b815c64b8) |



